### PR TITLE
feat: Rate-limit and queue Slack webhook messages, handle 429s

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@risk-labs/logger",
-  "version": "1.3.12",
+  "version": "1.3.13-alpha.0",
   "description": "Logger library",
   "dependencies": {
     "@discordjs/rest": "^2.6.1",

--- a/src/logger/SlackTransport.ts
+++ b/src/logger/SlackTransport.ts
@@ -175,6 +175,8 @@ class SlackHook extends Transport {
   // One FIFO queue and at most one in-flight drain per webhook URL (Slack's rate limit is per-webhook).
   private readonly queues = new Map<string, { body: unknown; attempts: number }[]>();
   private readonly draining = new Set<string>();
+  // Timestamp of the last POST per webhook, so spacing holds even across separate drain sessions.
+  private readonly lastSendAt = new Map<string, number>();
 
   constructor(opts: Options) {
     super(opts);
@@ -220,6 +222,12 @@ class SlackHook extends Transport {
     void this.drain(webhookUrl);
   }
 
+  // Getter for checking if the transport is flushed (waitForLogger blocks on this before a bot exits).
+  get isFlushed(): boolean {
+    if (this.draining.size > 0) return false;
+    return Array.from(this.queues.values()).every((queue) => queue.length === 0);
+  }
+
   // Drains a webhook's queue one message at a time, spaced by minSendIntervalMs, retrying 429s and 5xx.
   private async drain(webhookUrl: string): Promise<void> {
     if (this.draining.has(webhookUrl)) return;
@@ -227,14 +235,20 @@ class SlackHook extends Transport {
     const queue = this.queues.get(webhookUrl) ?? [];
     try {
       while (queue.length > 0) {
+        // Enforce spacing against the previous POST, even when it happened in an earlier drain session.
+        const sinceLast = Date.now() - (this.lastSendAt.get(webhookUrl) ?? -Infinity);
+        if (sinceLast < this.minSendIntervalMs) await sleep(this.minSendIntervalMs - sinceLast);
         const message = queue[0];
         message.attempts += 1;
+        this.lastSendAt.set(webhookUrl, Date.now());
         const retryMs = await this.deliver(webhookUrl, message.body);
         if (retryMs !== null && message.attempts <= MAX_RETRIES) {
           await sleep(retryMs); // wait Slack's Retry-After (or fallback), then retry the same message
-        } else {
-          queue.shift(); // delivered, permanently failed, or out of retries
-          if (queue.length > 0) await sleep(this.minSendIntervalMs);
+        } else if (queue[0] === message) {
+          // Delivered, permanently failed, or out of retries. The identity check matters: under overload,
+          // enqueue's drop-oldest may already have shifted this message out while the POST was in flight,
+          // and blindly shifting here would silently drop a message that was never attempted.
+          queue.shift();
         }
       }
     } finally {

--- a/src/logger/SlackTransport.ts
+++ b/src/logger/SlackTransport.ts
@@ -25,8 +25,6 @@ import Transport from "winston-transport";
 import axios from "axios";
 import type { AxiosInstance, AxiosRequestConfig } from "axios";
 
-import { TransportError } from "./TransportError";
-
 interface MarkdownText {
   type: "mrkdwn";
   text: string;
@@ -151,11 +149,20 @@ interface Options extends TransportOptions {
   transportConfig: {
     escalationPathWebhookUrls?: { [key: string]: string };
     defaultWebHookUrl: string;
+    // Minimum spacing between two POSTs to the same webhook — the "emit at a specific rate" lever.
+    // Optional; defaults to DEFAULT_MIN_SEND_INTERVAL_MS (~1 msg/sec, just under Slack's webhook limit).
+    minSendIntervalMs?: number;
   };
   formatter: (info: any) => SlackFormatterResponse;
   mrkdwn?: boolean;
   proxy?: AxiosRequestConfig["proxy"];
 }
+
+// Slack incoming webhooks allow ~1 request/second/webhook, so the default spacing stays just under that.
+export const DEFAULT_MIN_SEND_INTERVAL_MS = 1100;
+const MAX_RETRIES = 5; // attempts for a single message before it is dropped
+const MAX_QUEUE_SIZE = 1000; // messages buffered per webhook before the oldest are dropped (bounds memory)
+const RETRY_FALLBACK_MS = 1000; // retry wait when Slack sent no Retry-After (5xx / network error)
 
 class SlackHook extends Transport {
   private name: string;
@@ -164,6 +171,10 @@ class SlackHook extends Transport {
   private readonly formatter: (info: any) => SlackFormatterResponse;
   private readonly mrkdwn: boolean;
   private readonly axiosInstance: AxiosInstance;
+  private readonly minSendIntervalMs: number;
+  // One FIFO queue and at most one in-flight drain per webhook URL (Slack's rate limit is per-webhook).
+  private readonly queues = new Map<string, { body: unknown; attempts: number }[]>();
+  private readonly draining = new Set<string>();
 
   constructor(opts: Options) {
     super(opts);
@@ -173,15 +184,12 @@ class SlackHook extends Transport {
     this.defaultWebHookUrl = opts.transportConfig.defaultWebHookUrl;
     this.formatter = opts.formatter;
     this.mrkdwn = opts.mrkdwn || false;
-    this.axiosInstance = axios.create({
-      proxy: opts.proxy,
-      validateStatus: (status) => {
-        return status == 200;
-      },
-    });
+    this.minSendIntervalMs = opts.transportConfig.minSendIntervalMs ?? DEFAULT_MIN_SEND_INTERVAL_MS;
+    // Accept every status so we can read 429s (and their Retry-After) instead of letting axios throw.
+    this.axiosInstance = axios.create({ proxy: opts.proxy, validateStatus: () => true });
   }
 
-  async log(info: any, callback: (error?: unknown) => void): Promise<void> {
+  log(info: any, callback: (error?: unknown) => void): void {
     try {
       // If the log contains a notification path then use a custom slack webhook service. This lets the transport route to
       // different slack channels depending on the context of the log.
@@ -190,21 +198,73 @@ class SlackHook extends Transport {
       const payload: { blocks?: Block[]; text?: string; mrkdwn?: boolean } = { mrkdwn: this.mrkdwn };
       const layout = this.formatter(info);
       payload.blocks = layout.blocks || undefined;
-      // If the overall payload is less than 3000 chars then we can send it all in one go to the slack API.
-      if (JSON.stringify(payload).length < SLACK_MAX_CHAR_LIMIT) {
-        await this.axiosInstance.post(webhookUrl, payload);
-      } else {
-        // Iterate over each message to send and generate a axios call for each message.
-        for (const processedBlock of processMessageBlocks(payload.blocks)) {
-          payload.blocks = processedBlock;
-          await this.axiosInstance.post(webhookUrl, payload);
+      // Split a >3000-char payload into several slack messages; otherwise send it as one.
+      const bodies =
+        JSON.stringify(payload).length < SLACK_MAX_CHAR_LIMIT
+          ? [payload]
+          : processMessageBlocks(payload.blocks ?? []).map((blocks) => ({ ...payload, blocks }));
+      for (const body of bodies) this.enqueue(webhookUrl, body);
+    } catch (error) {
+      // Don't surface errors back through winston — that makes it try to log the failure, which in
+      // serverless mode emits the noisy "Attempt to write logs with no transports" warning we're killing.
+      // eslint-disable-next-line no-console
+      console.warn("[SlackTransport] Failed to enqueue Slack message:", error);
+    }
+    callback(); // accepted into the queue; let winston proceed without waiting for delivery
+  }
+
+  private enqueue(webhookUrl: string, body: unknown): void {
+    const queue = this.queues.get(webhookUrl) ?? this.queues.set(webhookUrl, []).get(webhookUrl)!;
+    if (queue.length >= MAX_QUEUE_SIZE) queue.shift(); // bound memory: drop oldest under a sustained backlog
+    queue.push({ body, attempts: 0 });
+    void this.drain(webhookUrl);
+  }
+
+  // Drains a webhook's queue one message at a time, spaced by minSendIntervalMs, retrying 429s and 5xx.
+  private async drain(webhookUrl: string): Promise<void> {
+    if (this.draining.has(webhookUrl)) return;
+    this.draining.add(webhookUrl);
+    const queue = this.queues.get(webhookUrl) ?? [];
+    try {
+      while (queue.length > 0) {
+        const message = queue[0];
+        message.attempts += 1;
+        const retryMs = await this.deliver(webhookUrl, message.body);
+        if (retryMs !== null && message.attempts <= MAX_RETRIES) {
+          await sleep(retryMs); // wait Slack's Retry-After (or fallback), then retry the same message
+        } else {
+          queue.shift(); // delivered, permanently failed, or out of retries
+          if (queue.length > 0) await sleep(this.minSendIntervalMs);
         }
       }
-    } catch (error) {
-      return callback(new TransportError("Slack", error, info));
+    } finally {
+      this.draining.delete(webhookUrl);
     }
-    callback();
   }
+
+  // POSTs once. Returns ms to wait before retrying (429/5xx/network), or null when there's nothing to retry.
+  private async deliver(webhookUrl: string, body: unknown): Promise<number | null> {
+    try {
+      const { status, headers } = await this.axiosInstance.post(webhookUrl, body);
+      if (status === 200) return null; // delivered
+      if (status === 429) return parseRetryAfterMs(headers?.["retry-after"]) ?? RETRY_FALLBACK_MS;
+      if (status >= 500) return RETRY_FALLBACK_MS;
+      return null; // permanent 4xx (bad payload / disabled webhook) — don't retry
+    } catch {
+      return RETRY_FALLBACK_MS; // network error — retry
+    }
+  }
+}
+
+// Parse a Slack Retry-After header (integer seconds) into milliseconds; null when absent/unparseable.
+export function parseRetryAfterMs(headerValue: unknown): number | null {
+  if (headerValue == null) return null;
+  const seconds = Number(Array.isArray(headerValue) ? headerValue[0] : headerValue);
+  return Number.isFinite(seconds) && seconds >= 0 ? Math.ceil(seconds * 1000) : null;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function processMessageBlocks(blocks: Block[]): Block[][] {

--- a/test/logger/SlackTransport.queue.js
+++ b/test/logger/SlackTransport.queue.js
@@ -45,6 +45,30 @@ describe("SlackTransport: rate-limited delivery", function () {
     assert.equal(post.callCount, 3);
   });
 
+  it("enforces spacing across drain sessions (an emptied queue does not reset the rate limit)", async function () {
+    const t = transport();
+    emit(t, 1);
+    assert.equal(post.callCount, 1);
+    await clock.tickAsync(400); // queue fully drained; next message arrives shortly after
+    emit(t, 2);
+    assert.equal(post.callCount, 1, "second send must wait out the remainder of the interval");
+    await clock.tickAsync(599);
+    assert.equal(post.callCount, 1);
+    await clock.tickAsync(1);
+    assert.equal(post.callCount, 2, "second send fires one interval after the first");
+  });
+
+  it("reports isFlushed only once every queue has drained (waitForLogger relies on this)", async function () {
+    const t = transport();
+    assert.isTrue(t.isFlushed, "flushed before anything is queued");
+    emit(t, 1);
+    emit(t, 2);
+    assert.isFalse(t.isFlushed, "not flushed while messages are queued or in flight");
+    await clock.tickAsync(1000); // first sends immediately, second one interval later
+    assert.equal(post.callCount, 2);
+    assert.isTrue(t.isFlushed, "flushed after the queue drains");
+  });
+
   it("waits the Retry-After duration on a 429 and then redelivers", async function () {
     post.onCall(0).resolves({ status: 429, headers: { "retry-after": "2" } });
     post.onCall(1).resolves({ status: 200, headers: {} });

--- a/test/logger/SlackTransport.queue.js
+++ b/test/logger/SlackTransport.queue.js
@@ -1,0 +1,75 @@
+const { assert } = require("chai");
+const sinon = require("sinon");
+const axios = require("axios");
+const { createSlackTransport, parseRetryAfterMs } = require("../../dist/logger/SlackTransport");
+
+describe("SlackTransport: rate-limited delivery", function () {
+  let clock, post;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    post = sinon.stub().resolves({ status: 200, headers: {} });
+    sinon.stub(axios, "create").returns({ post });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+    clock.restore();
+  });
+
+  // createSlackTransport calls axios.create(), so the stub above is what the transport POSTs through.
+  const transport = (overrides) =>
+    createSlackTransport({ defaultWebHookUrl: "https://hooks.slack.com/x", minSendIntervalMs: 1000, ...overrides });
+  const emit = (t, n) => t.log({ level: "warn", at: "Test", message: "m" + n }, () => {});
+
+  it("parseRetryAfterMs parses integer seconds and rejects junk", function () {
+    assert.equal(parseRetryAfterMs("3"), 3000);
+    assert.equal(parseRetryAfterMs(["5"]), 5000); // header may arrive as an array
+    assert.equal(parseRetryAfterMs(undefined), null);
+    assert.equal(parseRetryAfterMs("nope"), null);
+    assert.equal(parseRetryAfterMs("-1"), null);
+  });
+
+  it("sends the first message immediately and spaces the rest by minSendIntervalMs", async function () {
+    const t = transport();
+    emit(t, 1);
+    emit(t, 2);
+    emit(t, 3);
+
+    assert.equal(post.callCount, 1); // first send fires immediately
+    await clock.tickAsync(0);
+    assert.equal(post.callCount, 1, "no second send before the interval elapses");
+    await clock.tickAsync(1000);
+    assert.equal(post.callCount, 2);
+    await clock.tickAsync(1000);
+    assert.equal(post.callCount, 3);
+  });
+
+  it("waits the Retry-After duration on a 429 and then redelivers", async function () {
+    post.onCall(0).resolves({ status: 429, headers: { "retry-after": "2" } });
+    post.onCall(1).resolves({ status: 200, headers: {} });
+
+    emit(transport(), 1);
+    assert.equal(post.callCount, 1);
+    await clock.tickAsync(1999);
+    assert.equal(post.callCount, 1, "must not retry before Retry-After elapses");
+    await clock.tickAsync(1);
+    assert.equal(post.callCount, 2, "retries once Retry-After has elapsed");
+  });
+
+  it("drops a message after MAX_RETRIES of 5xx and stops retrying", async function () {
+    post.resolves({ status: 500, headers: {} });
+    emit(transport(), 1);
+
+    await clock.tickAsync(60_000); // far past all retry waits
+    assert.equal(post.callCount, 6, "1 initial attempt + 5 retries, then dropped");
+  });
+
+  it("does not retry permanent 4xx failures", async function () {
+    post.resolves({ status: 400, headers: {} });
+    emit(transport(), 1);
+
+    await clock.tickAsync(60_000);
+    assert.equal(post.callCount, 1, "a permanent failure is attempted once and dropped");
+  });
+});


### PR DESCRIPTION
## Problem

`SlackTransport` POSTs one webhook request per log line, inline, with the axios client set to `validateStatus: status == 200`. So when Slack returns **429** (its incoming webhooks are limited to ~1 msg/sec/webhook), axios throws, the error is caught, and the log line is **dropped** — no retry, and the `Retry-After` header is ignored. A bot that bursts warn/info volume trips 429s immediately and repeatedly. Each failure is also handed back through winston's callback, which makes winston try to log the failure and (in serverless mode) emit the noisy `Attempt to write logs with no transports` warning — so every drop produces *two* junk log lines.

We were seeing ~100 of these/hour across the Across bots, all of it Slack self-throttling (not RPC/chain rate limits).

## Change

Adds a small per-webhook queue inside `SlackHook` (no new classes/deps):

- **Bounded send rate** — drains a webhook's queue one message at a time, spaced by `minSendIntervalMs` (default **1100ms**, just under Slack's ~1 req/sec/webhook). The spacing is tracked per webhook against the last POST, so it holds across drain sessions (a trickle that lets the queue empty between messages is still rate-limited). This is the "emit at a specific rate" lever, configurable via `SLACK_CONFIG`.
- **429 handling** — on 429, waits the server's `Retry-After` (fixed fallback delay otherwise) and retries up to `MAX_RETRIES`; also retries 5xx / network errors; drops permanent 4xx (bad payload, disabled/unknown webhook) instead of hammering Slack.
- **Bounded memory** — a per-webhook cap drops the oldest message under a sustained backlog.
- **Exit flush** — the transport exposes an `isFlushed` getter (the `PersistentTransport` convention), so bots that call `waitForLogger` before exiting block until the queues drain, capped by the logger's `flushTimeout`.
- **No more meta-noise** — messages are accepted into the queue and winston proceeds immediately; failed sends are handled internally and never surfaced back through winston, so the `no transports` warnings stop.

Queues are keyed per webhook URL (Slack's limit is per-webhook), so a flood to one channel doesn't stall an escalation-path webhook.

## Why in-memory and not the Redis `PersistentTransport`

The repo already has `PersistentTransport` (Redis-backed, globally rate-limited) — but it was built for **Discord ticketing**: ~20s spacing, low volume, high per-message value, where persisting across short runs to guarantee delivery earns its keep. Slack *log* messages are the opposite (high volume, low value, ~1/sec limit that drains a backlog fast), and the 429s we saw came from **single bots each bursting hundreds of lines per cycle** — which a per-process in-memory queue fixes completely, without a Redis round-trip + availability dependency on the hot logging path.

Two things this deliberately does *not* do, both fine for log chatter: the limit is **per process** (many bots fanning out to the *same* webhook can still collectively nudge over, but it now backs off on `Retry-After` and degrades gracefully instead of spinning), and a process that hard-exits without `waitForLogger` still loses whatever is queued (the inline version already lost in-flight logs on exit).

## Test plan

`test/logger/SlackTransport.queue.js` drives the transport with sinon fake timers and a stubbed axios: rate spacing (within and across drain sessions), `Retry-After` wait + redelivery, drop-after-`MAX_RETRIES` (5xx), permanent-4xx no-retry, `isFlushed` semantics, and `Retry-After` parsing. `yarn build`, `yarn test` (17 passing), and `yarn prettier:check` all green locally.
