### PR TITLE
fix: fall back to console transport for transport-error logging

### DIFF
--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -31,6 +31,7 @@ import winston from "winston";
 import { PagerDutyTransport } from "./PagerDutyTransport";
 import { PagerDutyV2Transport } from "./PagerDutyV2Transport";
 import { TransportError } from "./TransportError";
+import { createConsoleTransport } from "./ConsoleTransport";
 import { createTransports } from "./Transports";
 import { botIdentifyFormatter, errorStackTracerFormatter, bigNumberFormatter } from "./Formatters";
 import { noBotId } from "../constants";
@@ -98,12 +99,15 @@ function createBaseLogger(
 
 // Filter to select reliable transports that can be used to log transport execution errors from other transports.
 // Currently only PagerDuty transports are supported and only if they are explicitly configured to log transport errors.
+// When none are configured, fall back to a console transport: without it the transport-error logger has no
+// transports at all and failures of the primary transports are silently dropped.
 function filterLogErrorTransports(transports: Transport[]): Transport[] {
-  return transports.filter(
+  const errorTransports = transports.filter(
     (transport) =>
       (transport instanceof PagerDutyTransport || transport instanceof PagerDutyV2Transport) &&
       transport.logTransportErrors,
   );
+  return errorTransports.length > 0 ? errorTransports : [createConsoleTransport()];
 }
 
 // Signal pause queue processing from persistent storage on all transports that support it.


### PR DESCRIPTION
## Motivation

During the 2026-07-24/25 `zion-across-same-asset-rebalancer` incident (Across relayer repo), the serverless bot children hit hanging Cloud Logging API writes (60s gax timeouts). The resulting transport errors were routed to the dedicated `transportErrorLogger`, but `filterLogErrorTransports` only accepts PagerDuty transports with `logTransportErrors` — and those children run with PagerDuty disabled. The transport-error logger therefore had zero transports and every report degraded to a bare `[winston] Attempt to write logs with no transports` warning, making the log-transport breakage invisible.

## Changes

When no qualifying PagerDuty transport exists, fall back to a console transport so primary-transport failures always reach container logs.

Related: the affected bots should also move to `ENVIRONMENT=serverless-gcp` (added in #26, published in 1.3.12) to avoid the Cloud Logging API write path entirely — being coordinated in the relayer/zion repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)