### PR TITLE
chore: bump version to 1.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@risk-labs/logger",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Logger library",
   "dependencies": {
     "@discordjs/rest": "^2.6.1",


### PR DESCRIPTION
Patch release for #28 (console-transport fallback for transport-error logging), so it can be pulled into the relayer repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)