### PR TITLE
fix(ci): use node 22 and pinned npm major in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,11 +37,13 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      # Pinned to a major rather than `latest`: npm majors raise their required node version over time
+      # (npm@12 dropped node 20 and broke this workflow), so `latest` can break the release at any moment.
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12
 
       - name: Log Node & npm versions (after update)
         # Make sure we hit 11.5.1 version requirement for Trusted Publishing


### PR DESCRIPTION
## Motivation

The v1.3.13 release failed at the `Update npm` step: `npm install -g npm@latest` now resolves to npm 12.0.1, which requires node `^22.22.2 || ^24.15.0 || >=26.0.0`, while the workflow sets up node 20.

## Changes

- `setup-node`: node 20 → 22.
- Pin the npm upgrade to the v12 major instead of `latest` (still satisfies the >=11.5.1 Trusted Publishing requirement), so a future npm major that drops node 22 can't silently break releases.

## Releasing 1.3.13 after this merges

`release` events run the workflow file from the commit the tag points at — so the existing v1.3.13 release/tag would still use the broken workflow. After merging, delete the v1.3.13 release and tag, and recreate them pointing at the new main head (package.json is already at 1.3.13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)