### PR TITLE
fix: silence dotenv startup log message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@risk-labs/logger",
-  "version": "1.3.13",
+  "version": "1.3.14",
   "description": "Logger library",
   "dependencies": {
     "@discordjs/rest": "^2.6.1",

--- a/src/logger/Transports.ts
+++ b/src/logger/Transports.ts
@@ -22,7 +22,8 @@ import type Transport from "winston-transport";
 import dotenv from "dotenv";
 import minimist from "minimist";
 
-dotenv.config();
+// quiet suppresses dotenv's startup log line; this config() runs as an import side effect in every consumer.
+dotenv.config({ quiet: true });
 const argv = minimist(process.argv.slice(), {});
 
 type SlackConfig = Parameters<typeof createSlackTransport>[0];


### PR DESCRIPTION
## Motivation

`dotenv@17` prints an advert on every `config()` call:

```
◇ injected env (N) from .env // tip: ◈ secrets for agents [www.dotenvx.com]
```

`Transports.ts` runs `config()` at import time, so **every consumer of `@risk-labs/logger`** (relayer bots included) gets this banner on startup, regardless of their own dotenv version.

## What

- Pass `{ quiet: true }` — dotenv's documented suppression option. Verified against `dotenv@17.4.2`: banner prints with a bare `config()`, fully silent with `{ quiet: true }`.
- Bump patch version to 1.3.14.

`yarn build`, `yarn prettier:check`, and `yarn test` (10 passing) are green.

Supersedes the consumer-side workaround in across-protocol/relayer#3641 (closed in favor of this). Once published, consumers just need a lockfile refresh to pick it up.

Requested by Paul in Slack: https://risklabs.slack.com/archives/C0BHMM63D9Q/p1785316898296319

🤖 Generated with [Claude Code](https://claude.com/claude-code)